### PR TITLE
Removing any mention of Sphinx

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,4 +25,4 @@
 - [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Ce11an/spacy-cleaner/blob/main/CONTRIBUTING.md) guide.
 - [ ] I've updated the code style using `make codestyle`.
 - [ ] I've written tests for all new methods and classes that I created.
-- [ ] I've written the docstring in Sphinx format for all the methods and classes that I used.
+- [ ] I've written the docstring in Google style format for all the methods and classes that I used.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [darglint]
 # https://github.com/terrencepreilly/darglint
 strictness = long
-docstring_style = sphinx
+docstring_style = google


### PR DESCRIPTION
## Description

Documentation is now written in Google-style format. Editing some previously missed files.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Ce11an/spacy-cleaner/blob/mian/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/Ce11an/spacy-cleaner/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Sphinx format for all the methods and classes that I used.
