### PR TITLE
Fixing typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Class `Pipeline` allows for configurable cleaning of text using `spaCy`. The
 pipeline = spacy_cleaner.Pipeline(
     model,
     removers.remove_stopword_token,
-    replace.replace_punctuation_token,
+    replacers.replace_punctuation_token,
     mutators.mutate_lemma_token,
 )
 ```
@@ -91,7 +91,7 @@ https://spacy.io/api/language#pipe
 
 Giving the output:
 ```python
-['Hello _IS_PUNCT_ Cellan _IS_PUNCT_ love swim _IS_PUNCT_']
+['hello _IS_PUNCT_ Cellan _IS_PUNCT_ love swim _IS_PUNCT_']
 ```
 
 ### Makefile usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ Class `Pipeline` allows for configurable cleaning of text using `spaCy`. The
 pipeline = spacy_cleaner.Pipeline(
     model,
     removers.remove_stopword_token,
-    replace.replace_punctuation_token,
+    replacers.replace_punctuation_token,
     mutators.mutate_lemma_token,
 )
 ```
@@ -73,5 +73,5 @@ https://spacy.io/api/language#pipe
 
 Giving the output:
 ```python
-['Hello _IS_PUNCT_ Cellan _IS_PUNCT_ love swim _IS_PUNCT_']
+['hello _IS_PUNCT_ Cellan _IS_PUNCT_ love swim _IS_PUNCT_']
 ```

--- a/spacy_cleaner/cleaning/pipeline.py
+++ b/spacy_cleaner/cleaning/pipeline.py
@@ -36,7 +36,7 @@ class Pipeline(BaseCleaner):
             mutate_lemma_token,
         )
         pipline.clean(texts)
-        ['Hello _IS_PUNCT_ Cellan _IS_PUNCT_ love swim _IS_PUNCT_']
+        ['hello _IS_PUNCT_ Cellan _IS_PUNCT_ love swim _IS_PUNCT_']
         ```
     """
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

Found some typos in our documentation that needed to be addressed.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/Ce11an/spacy-cleaner/blob/mian/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/Ce11an/spacy-cleaner/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google style format for all the methods and classes that I used.
